### PR TITLE
fix(#158): use double for currency formatting not float

### DIFF
--- a/src/java/org/eurofurence/regsys/web/forms/AccountingSearchForm.java
+++ b/src/java/org/eurofurence/regsys/web/forms/AccountingSearchForm.java
@@ -339,7 +339,7 @@ public class AccountingSearchForm extends Form {
             if (Transaction.TransactionType.PAYMENT.getValue().equals(found.get(count).transactionType)) {
                 Transaction.Amount amount = found.get(count).amount;
                 if (amount != null) {
-                    return Util.toDecimals(amount.grossCent / 100.0f);
+                    return Util.toCurrencyDecimals(amount.grossCent);
                 } else {
                     return "???";
                 }
@@ -352,7 +352,7 @@ public class AccountingSearchForm extends Form {
             if (Transaction.TransactionType.DUE.getValue().equals(found.get(count).transactionType)) {
                 Transaction.Amount amount = found.get(count).amount;
                 if (amount != null) {
-                    return Util.toDecimals(amount.grossCent / 100.0f);
+                    return Util.toCurrencyDecimals(amount.grossCent);
                 } else {
                     return "???";
                 }

--- a/src/java/org/eurofurence/regsys/web/forms/FormHelper.java
+++ b/src/java/org/eurofurence/regsys/web/forms/FormHelper.java
@@ -73,8 +73,8 @@ public class FormHelper {
         return Util.testEmail(page::addError, input, field);
     }
 
-    public static String toDecimals(float f) {
-        return Util.toDecimals(f);
+    public static String toDecimals(double d) {
+        return Util.toDecimals(d);
     }
 
     public static String toCurrencyDecimals(Long cents) {

--- a/src/java/org/eurofurence/regsys/web/forms/InputForm.java
+++ b/src/java/org/eurofurence/regsys/web/forms/InputForm.java
@@ -585,16 +585,8 @@ public class InputForm extends Form {
 
         // attribute forwarders
 
-        private String str(int i) {
-            return Integer.toString(i);
-        }
-
         private String str(long i) {
             return Long.toString(i);
-        }
-
-        private String str(float f) {
-            return FormHelper.toDecimals(f);
         }
 
         public String getId() {

--- a/src/java/org/eurofurence/regsys/web/forms/Util.java
+++ b/src/java/org/eurofurence/regsys/web/forms/Util.java
@@ -266,11 +266,11 @@ public class Util {
 
     // Other data conversion helpers
 
-    public static String toDecimals(float f) {
+    public static String toDecimals(double d) {
         DecimalFormat format = new DecimalFormat("0.00");
-        String res = format.format(f);
+        String res = format.format(d);
         if (res != null) {
-          res = res.replace(',', '.'); // damn i8n
+            res = res.replace(',', '.'); // damn i8n
         }
         return res;
     }
@@ -278,7 +278,7 @@ public class Util {
     public static String toCurrencyDecimals(Long cents) {
         if (cents == null)
             return "UNKNOWN";
-        return toDecimals(cents/100f);
+        return toDecimals(cents/100d);
     }
 
     public static float toFloat(String s) {


### PR DESCRIPTION
This should be in the upcoming release. It's messing up the monetary sums in the statistics page.