### PR TITLE
chore(deps): dependency and documentation updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,19 +52,20 @@ dependencies {
     implementation 'org.apache.commons:commons-text:1.15.0'
     implementation 'org.slf4j:slf4j-api:2.0.18'
     implementation 'co.elastic.logging:logback-ecs-encoder:1.8.0'
-    implementation 'ch.qos.logback:logback-classic:1.5.32'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.21.3'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.21.3'
+    implementation 'ch.qos.logback:logback-classic:1.5.34'
+    // Jackson 2.21 is LTS: https://github.com/FasterXML/jackson/wiki/Jackson-Releases
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.21.4'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.21.4'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.21'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.3'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.4'
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation 'commons-beanutils:commons-beanutils:1.11.0'
     implementation 'commons-validator:commons-validator:1.10.1'
 
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.5'
-    implementation 'com.sun.xml.bind:jaxb-impl:4.0.8'
+    implementation 'com.sun.xml.bind:jaxb-impl:4.0.9'
 
-    // security updates
+    // security update for org.apache.httpcomponents:httpclient:4.5.14, references very old commons-codec
     implementation 'commons-codec:commons-codec:1.22.0'
 
     // embed tomcat 10.1

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.21.4'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.21'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.4'
+    // there is now v5, https://hc.apache.org/httpcomponents-client-5.6.x/migration-guide/migration-to-classic.html
+    // org.apache.httpcomponents.client5:httpclient5
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation 'commons-beanutils:commons-beanutils:1.11.0'
     implementation 'commons-validator:commons-validator:1.10.1'


### PR DESCRIPTION
Updates
- logback
- jackson 2.21 LTS latest
- jaxb

Document why transitive commons-codec is still needed.

Document path forward with httpclient5.